### PR TITLE
Show email in "Sent code via email" prompt

### DIFF
--- a/src/login.ts
+++ b/src/login.ts
@@ -46,9 +46,7 @@ let deviceid_placeholder = "device ID";
  */
 export function registerLoginCommand(command: string) {
   vscode.commands.registerCommand(command, () => {
-    vscode.window
-      .showQuickPick(loginMethods)
-      .then(handleLogin, loginError);
+    vscode.window.showQuickPick(loginMethods).then(handleLogin, loginError);
   });
 }
 
@@ -121,11 +119,7 @@ export function loginFromSavedState(saved_state: any) {
  * @example
  * getOrPrompt('email', 'Please enter your email', 'email@example.com')
  */
-function getOrPrompt(
-  section: string,
-  prompt: string,
-  placeHolder?: string
-) {
+function getOrPrompt(section: string, prompt: string, placeHolder?: string) {
   return new Promise<string | undefined>((resolve, reject) => {
     let config = vscode.workspace.getConfiguration("notion");
     let value: string = config.get(section) || "";
@@ -211,8 +205,7 @@ function handleLogin(method: vscode.QuickPickItem | undefined) {
 function loginError(error?: string) {
   let message = "Error while selecting login method";
 
-  if (typeof error === "undefined")
-    vscode.window.showErrorMessage(message);
+  if (typeof error === "undefined") vscode.window.showErrorMessage(message);
   else vscode.window.showErrorMessage(message + ": " + error);
 }
 
@@ -239,9 +232,7 @@ function sendLoginEmail() {
       handleCodeInApp: true
     })
     .then(loginWithEmailCred)
-    .catch(() =>
-      vscode.window.showErrorMessage("Error sending login email")
-    );
+    .catch(() => vscode.window.showErrorMessage("Error sending login email"));
 }
 
 function loginWithEmailCred() {
@@ -251,8 +242,7 @@ function loginWithEmailCred() {
 
   vscode.window
     .showInputBox({
-      prompt:
-        "Please enter the code obtained via the link in the email we sent you",
+      prompt: `Email sent to ${email}. Please enter the code obtained via the link in the email we sent you`,
       ignoreFocusOut: true,
       placeHolder: "code"
     })


### PR DESCRIPTION
Previously the prompt message was:

`Please enter the code obtained via the link in the email we sent you`

I've updated it to be:

`Email sent to ${email}. Please enter the code obtained via the link in the email we sent you`